### PR TITLE
add handler to inline template call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /blib/
-/.build/
+.build/
 _build/
 cover_db/
 inc/
@@ -10,6 +10,7 @@ Build.bat
 /Makefile
 /Makefile.old
 /MANIFEST.bak
+Mojolicious-Plugin-ReCAPTCHAv2-*
 /META.yml
 /META.json
 /MYMETA.*
@@ -19,3 +20,4 @@ nytprof.out
 *.bs
 /_eumm/
 *.swp
+*.tar.gz

--- a/Mojolicious-Plugin-ReCAPTCHAv2/lib/Mojolicious/Plugin/ReCAPTCHAv2.pm
+++ b/Mojolicious-Plugin-ReCAPTCHAv2/lib/Mojolicious/Plugin/ReCAPTCHAv2.pm
@@ -49,6 +49,7 @@ sub register {
 			# Compatibility with Mojolicious < 5.0
 			if ( $c->can('render_to_string') ) {
 				$output = $c->render_to_string(
+					handler => 'ep',
 					inline => $template,
 					hl     => $hl,
 					attr   => \%data_attr,
@@ -56,6 +57,7 @@ sub register {
 			}
 			else {
 				$output = $c->render(
+					handler => 'ep',
 					inline  => $template,
 					hl      => $hl,
 					attr    => \%data_attr,

--- a/Mojolicious-Plugin-ReCAPTCHAv2/t/11-basic-tt.t
+++ b/Mojolicious-Plugin-ReCAPTCHAv2/t/11-basic-tt.t
@@ -1,0 +1,34 @@
+#!perl
+# vim:syntax=perl:tabstop=4:number:noexpandtab:
+
+use Mojo::Base -strict;
+use Mojolicious::Lite;
+use Mojo::JSON qw();
+use Test::Mojo;
+use Test::More;
+
+plugin 'ReCAPTCHAv2' => {
+	'sitekey' => 'key',
+	'secret'  => 'secret',
+};
+
+get '/' => sub {
+	my $c = shift;
+	$c->render( text => $c->recaptcha_get_html );
+};
+
+# we override the default handler to check that the ep
+# handler is used for the inline template in the plugin
+app->renderer->default_handler('something_else');
+
+my $t = Test::Mojo->new;
+
+$t
+->get_ok('/')
+->status_is(200)
+->content_is(<<'RECAPTCHA');
+<script src="https://www.google.com/recaptcha/api.js?hl=" async defer></script>
+<div class="g-recaptcha" data-sitekey="key"></div>
+RECAPTCHA
+
+done_testing;


### PR DESCRIPTION
add template_format plugin config option

in the case of using alternate template rendering engines where the
app->renderer->default_handler is set to something other than the
mojo default of 'ep' as this will cause the template markup we are
using in recaptcha_get_html to not be interpolated

template_format will default to 'mojo', i.e. the embedded perl we
are already using, and can be overridden with 'tt' at present to
support Template::Toolkit markup. other markup formats could perhaps
be added
